### PR TITLE
feat: Add global jump functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,9 @@ To use JustJump, simply run `jj` in your terminal and select the directory you w
 jj
 ```
 
-You can also pass arguments to `justjump` or `jj`. For now only `--help` flag is supported.
-```sh
-jj --help
-```
+You can also pass arguments to `justjump` or `jj`.
+- `--help`: Display help information
+- `--global` or `-G`: Perform a global jump across registered projects
 
 ## Configuration
 

--- a/misc/rc/bash/.justjumprc
+++ b/misc/rc/bash/.justjumprc
@@ -1,22 +1,16 @@
 func_justjump () {
-    if [ $# -eq 0 ]; then
-        # No arguments passed, use shelloutput with a temporary file to provide a jump
-        TMPFILE=$(mktemp)
-        trap 'rm -f $TMPFILE' EXIT
-        if justjump --shelloutput $TMPFILE; then 
-            if [ -e "$TMPFILE" ]; then
-                JMPCMD=$(cat $TMPFILE)
-                history -s $(history 1 | cut -d' ' -f4-); history -s "$JMPCMD"
-                eval "$JMPCMD"
-            else
-                echo "Error extracting command"
-            fi
+    TMPFILE=$(mktemp)
+    trap 'rm -f $TMPFILE' EXIT
+    if justjump "$@" --shelloutput $TMPFILE; then 
+        if [ -e "$TMPFILE" ]; then
+            JMPCMD=$(cat $TMPFILE)
+            history -s $(history 1 | cut -d' ' -f4-); history -s "$JMPCMD"
+            eval "$JMPCMD"
         else
-            return 1
+            echo "Error extracting command"
         fi
     else
-        # Arguments passed, run justjump with the provided arguments
-        justjump "$@"
+        return 1
     fi
 }
 alias 'jj'=func_justjump

--- a/misc/rc/zsh/.justjumprc
+++ b/misc/rc/zsh/.justjumprc
@@ -1,22 +1,16 @@
 func_justjump () {
-    if [ $# -eq 0 ]; then
-        # No arguments passed, use shelloutput with a temporary file to provide a jump
-        TMPFILE=$(mktemp)
-        trap 'rm -f $TMPFILE' EXIT
-        if justjump --shelloutput $TMPFILE; then 
-            if [ -e "$TMPFILE" ]; then
-                JMPCMD=$(cat $TMPFILE)
-                fc -R $TMPFILE
-                eval "$JMPCMD"
-            else
-                echo "Error extracting command"
-            fi
+    TMPFILE=$(mktemp)
+    trap 'rm -f $TMPFILE' EXIT
+    if justjump "$@" --shelloutput $TMPFILE; then 
+        if [ -e "$TMPFILE" ]; then
+            JMPCMD=$(cat $TMPFILE)
+            fc -R $TMPFILE
+            eval "$JMPCMD"
         else
-            return 1
+            echo "Error extracting command"
         fi
     else
-        # Arguments passed, run justjump with the provided arguments
-        justjump "$@"
+        return 1
     fi
 }
 alias jj='func_justjump'

--- a/pkg/util/promptui/global/global.go
+++ b/pkg/util/promptui/global/global.go
@@ -1,0 +1,35 @@
+package global
+
+import (
+	"strings"
+
+	"github.com/manifoldco/promptui"
+)
+
+func promptSearcher(input string, index int, jumpRootPaths []map[string]string) bool {
+	jumpRoot := jumpRootPaths[index]
+	name := strings.Replace(strings.ToLower(jumpRoot["jumpRoot"]), " ", "", -1)
+	input = strings.Replace(strings.ToLower(input), " ", "", -1)
+
+	return strings.Contains(name, input)
+}
+
+func promptTemplates() *promptui.SelectTemplates {
+	return &promptui.SelectTemplates{
+		Label:    "{{ . }}?",
+		Active:   "\U0001F449 {{ .jumpRoot | cyan }} ({{ .fullPath | faint }})",
+		Inactive: "  {{ .jumpRoot | cyan }}",
+		Selected: "\U0001F449 {{ .jumpRoot | red }}",
+	}
+}
+
+func PromptSelector(jumpRootPaths []map[string]string) *promptui.Select {
+	return &promptui.Select{
+		Label:     "Select a jump root",
+		Items:     jumpRootPaths,
+		Templates: promptTemplates(),
+		Searcher: func(input string, index int) bool {
+			return promptSearcher(input, index, jumpRootPaths)
+		},
+	}
+}

--- a/pkg/util/promptui/local/local.go
+++ b/pkg/util/promptui/local/local.go
@@ -1,4 +1,4 @@
-package util
+package local
 
 import (
 	"strings"
@@ -6,7 +6,7 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
-func PromptSearcher(input string, index int, jumpPointPaths []map[string]string) bool {
+func promptSearcher(input string, index int, jumpPointPaths []map[string]string) bool {
 	jumpPoint := jumpPointPaths[index]
 	name := strings.Replace(strings.ToLower(jumpPoint["jumpPoint"]), " ", "", -1)
 	input = strings.Replace(strings.ToLower(input), " ", "", -1)
@@ -14,7 +14,7 @@ func PromptSearcher(input string, index int, jumpPointPaths []map[string]string)
 	return strings.Contains(name, input)
 }
 
-func PromptTemplates() *promptui.SelectTemplates {
+func promptTemplates() *promptui.SelectTemplates {
 	return &promptui.SelectTemplates{
 		Label:    "{{ . }}?",
 		Active:   "\U0001F449 {{ .jumpPoint | cyan }} ({{ .fullPath | faint }})",
@@ -27,9 +27,9 @@ func PromptSelector(jumpPointPaths []map[string]string) *promptui.Select {
 	return &promptui.Select{
 		Label:     "Select a jump point",
 		Items:     jumpPointPaths,
-		Templates: PromptTemplates(),
+		Templates: promptTemplates(),
 		Searcher: func(input string, index int) bool {
-			return PromptSearcher(input, index, jumpPointPaths)
+			return promptSearcher(input, index, jumpPointPaths)
 		},
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,6 +21,21 @@ func DetermineJumpRoot(currentDir string, jumpRoots global.JumpRoots) (bool, str
 	return exist, jumpRoot
 }
 
+func BuildJumpRootPaths(jumpRoots global.JumpRoots) []map[string]string {
+	jumpRootPaths := make([]map[string]string, 0)
+
+	for name, jr := range jumpRoots {
+		dict := map[string]string{
+			"jumpRoot": name,
+			"fullPath": jr.Root,
+		}
+
+		jumpRootPaths = append(jumpRootPaths, dict)
+	}
+
+	return jumpRootPaths
+}
+
 func BuildJumpPointPaths(jumpRoot string, jumpPoints []string) []map[string]string {
 	jumpPointPaths := make([]map[string]string, 0)
 	jumpPointPaths = append(jumpPointPaths, map[string]string{


### PR DESCRIPTION
This commit adds the ability to perform a global jump across registered projects. It introduces a new flag, `--global` or `-G`, which, when provided, allows the user to select a jump root from a list of registered jump roots. The selected jump root is then used to perform the jump.

The changes include:
- Adding a new boolean flag, `globalJump`, to the `rootCmd` struct in `root.go`
- Implementing the `performGlobalJump` function in `root.go` to handle the global jump logic
- Creating a new package, `promptui_global`, in `pkg/util/promptui/global/global.go`, which provides the UI prompt for selecting a jump root

This feature enhances the usability of the `justjump` command-line tool by allowing users to easily navigate between different projects.